### PR TITLE
Add persistent state to Quran player

### DIFF
--- a/src/components/QuranPlayer.jsx
+++ b/src/components/QuranPlayer.jsx
@@ -9,6 +9,18 @@ export default function QuranPlayer() {
   const [currentAyahIndex, setCurrentAyahIndex] = useState(0);
   const audioRef = useRef(null);
 
+  // Load saved state on mount so the user can resume where they left off
+  useEffect(() => {
+    const savedSurah = Number(localStorage.getItem('surahNumber'));
+    const savedIndex = Number(localStorage.getItem('currentAyahIndex'));
+    if (!Number.isNaN(savedSurah) && savedSurah > 0) {
+      setSurahNumber(savedSurah);
+    }
+    if (!Number.isNaN(savedIndex) && savedIndex >= 0) {
+      setCurrentAyahIndex(savedIndex);
+    }
+  }, []);
+
   useEffect(() => {
     fetch(`${API_BASE}/surah`)
       .then((res) => res.json())
@@ -26,7 +38,13 @@ export default function QuranPlayer() {
       .then((data) => {
         if (data.data && data.data.ayahs) {
           setAyahs(data.data.ayahs);
-          setCurrentAyahIndex(0);
+          const savedSurah = Number(localStorage.getItem('surahNumber'));
+          const savedIndex = Number(localStorage.getItem('currentAyahIndex'));
+          if (surahNumber === savedSurah && !Number.isNaN(savedIndex)) {
+            setCurrentAyahIndex(Math.min(savedIndex, data.data.ayahs.length - 1));
+          } else {
+            setCurrentAyahIndex(0);
+          }
         }
       })
       .catch((err) => console.error('Failed to fetch ayahs:', err));
@@ -50,6 +68,15 @@ export default function QuranPlayer() {
       audioRef.current.play();
     }
   };
+
+  // Persist surah and ayah index so progress is saved between sessions
+  useEffect(() => {
+    localStorage.setItem('surahNumber', String(surahNumber));
+  }, [surahNumber]);
+
+  useEffect(() => {
+    localStorage.setItem('currentAyahIndex', String(currentAyahIndex));
+  }, [currentAyahIndex]);
 
   useEffect(() => {
     if (audioRef.current) {


### PR DESCRIPTION
## Summary
- store current surah and ayah index to `localStorage`
- read saved values on mount so playback resumes where the user left off

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68861b67c5c08328bf0e919a99d6f7d3