### PR TITLE
Add translation editions to Quran player

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ npm run preview
 
 ## Usage
 
-The app now includes a simple Quran player that fetches surah and ayah data from [Al Quran Cloud](https://alquran.cloud/api) and allows audio playback with navigation controls. Modify `src/components/QuranPlayer.jsx` to extend the functionality further.
+The app now includes a simple Quran player that fetches surah and ayah data from [Al Quran Cloud](https://alquran.cloud/api) and allows audio playback with navigation controls. The player also supports selecting an English translation edition so the corresponding text appears alongside the Arabic verses. Modify `src/components/QuranPlayer.jsx` to extend the functionality further.
 

--- a/src/components/QuranPlayer.jsx
+++ b/src/components/QuranPlayer.jsx
@@ -1,11 +1,14 @@
 import { useEffect, useState, useRef } from 'react';
 
 const API_BASE = 'https://api.alquran.cloud/v1';
+const TRANSLATION_OPTIONS = ['en.asad', 'en.pickthall', 'en.sahih'];
 
 export default function QuranPlayer() {
   const [surahs, setSurahs] = useState([]);
   const [surahNumber, setSurahNumber] = useState(1);
+  const [translationEdition, setTranslationEdition] = useState('en.asad');
   const [ayahs, setAyahs] = useState([]);
+  const [translationAyahs, setTranslationAyahs] = useState([]);
   const [currentAyahIndex, setCurrentAyahIndex] = useState(0);
   const audioRef = useRef(null);
 
@@ -21,16 +24,19 @@ export default function QuranPlayer() {
   }, []);
 
   useEffect(() => {
-    fetch(`${API_BASE}/surah/${surahNumber}/ar.alafasy`)
+    fetch(
+      `${API_BASE}/surah/${surahNumber}/editions/ar.alafasy,${translationEdition}`
+    )
       .then((res) => res.json())
       .then((data) => {
-        if (data.data && data.data.ayahs) {
-          setAyahs(data.data.ayahs);
+        if (Array.isArray(data.data) && data.data.length >= 2) {
+          setAyahs(data.data[0].ayahs || []);
+          setTranslationAyahs(data.data[1].ayahs || []);
           setCurrentAyahIndex(0);
         }
       })
       .catch((err) => console.error('Failed to fetch ayahs:', err));
-  }, [surahNumber]);
+  }, [surahNumber, translationEdition]);
 
   const playAudio = () => {
     audioRef.current?.play();
@@ -74,10 +80,29 @@ export default function QuranPlayer() {
           ))}
         </select>
       </div>
+      <div style={{ marginTop: '0.5rem' }}>
+        <label htmlFor="edition-select">Edition:</label>{' '}
+        <select
+          id="edition-select"
+          value={translationEdition}
+          onChange={(e) => setTranslationEdition(e.target.value)}
+        >
+          {TRANSLATION_OPTIONS.map((e) => (
+            <option key={e} value={e}>
+              {e}
+            </option>
+          ))}
+        </select>
+      </div>
 
       {ayahs.length > 0 && (
         <div style={{ marginTop: '1rem' }}>
           <p>{ayahs[currentAyahIndex].text}</p>
+          {translationAyahs[currentAyahIndex] && (
+            <p style={{ fontStyle: 'italic' }}>
+              {translationAyahs[currentAyahIndex].text}
+            </p>
+          )}
           <audio
             ref={audioRef}
             controls


### PR DESCRIPTION
## Summary
- extend QuranPlayer to fetch translation editions alongside Arabic text
- allow user to select translation edition through new UI select
- display chosen translation for each ayah
- document translation feature in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68861b6d424c832883b9c0a1b7a869ef